### PR TITLE
Fix toml-rs valid/spec/float-0 failure

### DIFF
--- a/scripts/Cargo.lock
+++ b/scripts/Cargo.lock
@@ -514,11 +514,12 @@ dependencies = [
 
 [[package]]
 name = "toml-test"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47dfa19ca3d6591b3151156884e0345e646307299a111391c54b0a7bd33bb04"
+checksum = "f76ff6290013b41ffa06d30be167bca0d5798f296fcaf5b18892f2b3d7d75701"
 dependencies = [
  "chrono",
+ "ryu",
  "serde",
  "serde_json",
 ]
@@ -534,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "toml-test-harness"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7346ccc45965d33ad1a15e558bc67f8c7a35a72d882f646c342fea9227390296"
+checksum = "69f459a52d9e76baee240ab8463e0a830f70993457ad5c6f9d75e449cbda3246"
 dependencies = [
  "ignore",
  "libtest-mimic",

--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -11,8 +11,8 @@ publish = false
 basic-toml = "0.1.4"
 serde_json = "1.0.107"
 toml = "0.8.2"
-toml-test = "0.3.6"
-toml-test-harness = "0.4.5"
+toml-test = "0.3.7"
+toml-test-harness = "0.4.7"
 toml_edit = "0.20.2"
 
 [profile.release]


### PR DESCRIPTION
The helper code was incorrectly rendering the float; the parser worked fine.  I just never bothed investigating how to fix it since no one would notice this incorrect failure before.