### PR TITLE
Add rust-boml

### DIFF
--- a/parsers/rust-boml.zsh
+++ b/parsers/rust-boml.zsh
@@ -1,0 +1,17 @@
+deps() { print 'cargo rustc' }
+
+setup() {
+	cd scripts
+	cargo build --release
+}
+
+typeset -A info=(
+	lang    'Rust'
+	toml    '1.0'
+	site    'https://github.com/Bright-Shard/boml/tree/main'
+	src     '' # We use the Cargo.toml for now 'https://github.com/toml-rs/toml.git'
+	version '0.3.1'
+	decoder './scripts/target/release/boml-decoder'
+	encoder './scripts/target/release/boml-encoder'
+	perf    './scripts/target/release/rust-boml-perf'
+)

--- a/scripts/Cargo.lock
+++ b/scripts/Cargo.lock
@@ -100,6 +100,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "boml"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85fdb93f04c73bff54305fa437ffea5449c41edcaadfe882f35836206b166ac5"
+
+[[package]]
 name = "bstr"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +496,23 @@ version = "0.0.0"
 dependencies = [
  "basic-toml",
  "toml",
+]
+
+[[package]]
+name = "rust-boml"
+version = "0.0.0"
+dependencies = [
+ "boml",
+ "serde_json",
+ "toml-test",
+ "toml-test-harness",
+]
+
+[[package]]
+name = "rust-boml-perf"
+version = "0.0.0"
+dependencies = [
+ "boml",
 ]
 
 [[package]]

--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 
 [workspace.dependencies]
 basic-toml = "0.1.9"
+boml = "0.3.1"
 serde_json = "1.0.107"
 taplo = { version = "0.13.0", features = ["serde"] }
 toml = "0.8.13"

--- a/scripts/rust-boml-perf/Cargo.toml
+++ b/scripts/rust-boml-perf/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rust-boml-perf"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+boml.workspace = true

--- a/scripts/rust-boml-perf/src/main.rs
+++ b/scripts/rust-boml-perf/src/main.rs
@@ -1,0 +1,11 @@
+fn main() {
+    let mut args = std::env::args_os();
+    args.next();
+    let path = std::path::PathBuf::from(args.next().expect("Missing TOML path argument"));
+    let raw = std::fs::read_to_string(&path).unwrap();
+    let timer = std::time::Instant::now();
+    let value = boml::Toml::parse(&raw);
+    let delta = timer.elapsed().as_secs_f32();
+    value.unwrap();
+    println!("{delta}");
+}

--- a/scripts/rust-boml/Cargo.toml
+++ b/scripts/rust-boml/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust-boml"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+serde_json.workspace = true
+boml.workspace = true
+toml-test.workspace = true
+toml-test-harness.workspace = true

--- a/scripts/rust-boml/src/bin/boml-decoder.rs
+++ b/scripts/rust-boml/src/bin/boml-decoder.rs
@@ -1,0 +1,17 @@
+use std::io::Read as _;
+
+use toml_test_harness::Decoder as _;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut stdin = std::io::stdin();
+    let mut raw = String::new();
+    stdin.read_to_string(&mut raw)?;
+
+    let decoded = rust_boml::decoder::Decoder.decode(raw.as_bytes())?;
+
+    let json = serde_json::to_string_pretty(&decoded)?;
+
+    print!("{json}");
+
+    Ok(())
+}

--- a/scripts/rust-boml/src/decoder.rs
+++ b/scripts/rust-boml/src/decoder.rs
@@ -1,0 +1,66 @@
+#[derive(Copy, Clone)]
+pub struct Decoder;
+
+impl toml_test_harness::Decoder for Decoder {
+    fn name(&self) -> &str {
+        "toml"
+    }
+
+    fn decode(&self, data: &[u8]) -> Result<toml_test_harness::Decoded, toml_test_harness::Error> {
+        let data = std::str::from_utf8(data).map_err(toml_test_harness::Error::new)?;
+        let table = boml::Toml::parse(&data)
+            .map_err(|err| toml_test_harness::Error::new(format!("{err:?}")))?
+            .into_table();
+        table_to_decoded(&table)
+    }
+}
+
+fn value_to_decoded(
+    value: &boml::types::TomlValue,
+) -> Result<toml_test_harness::Decoded, toml_test_harness::Error> {
+    match value {
+        boml::types::TomlValue::Integer(v) => Ok(toml_test_harness::Decoded::Value(
+            toml_test_harness::DecodedValue::from(*v),
+        )),
+        boml::types::TomlValue::String(v) => Ok(toml_test_harness::Decoded::Value(
+            toml_test_harness::DecodedValue::from(v.as_str()),
+        )),
+        boml::types::TomlValue::Float(v) => Ok(toml_test_harness::Decoded::Value(
+            toml_test_harness::DecodedValue::from(*v),
+        )),
+        boml::types::TomlValue::OffsetDateTime => Ok(toml_test_harness::Decoded::Value(
+            toml_test_harness::DecodedValue::from("OffsetDateTime"),
+        )),
+        boml::types::TomlValue::LocalDateTime => Ok(toml_test_harness::Decoded::Value(
+            toml_test_harness::DecodedValue::from("LocalDateTime"),
+        )),
+        boml::types::TomlValue::LocalDate => Ok(toml_test_harness::Decoded::Value(
+            toml_test_harness::DecodedValue::from("LocalDate"),
+        )),
+        boml::types::TomlValue::LocalTime => Ok(toml_test_harness::Decoded::Value(
+            toml_test_harness::DecodedValue::from("LocalTime"),
+        )),
+        boml::types::TomlValue::Boolean(v) => Ok(toml_test_harness::Decoded::Value(
+            toml_test_harness::DecodedValue::from(*v),
+        )),
+        boml::types::TomlValue::Array(v) => {
+            let v: Result<_, toml_test_harness::Error> = v.iter().map(value_to_decoded).collect();
+            Ok(toml_test_harness::Decoded::Array(v?))
+        }
+        boml::types::TomlValue::Table(v) => table_to_decoded(v),
+    }
+}
+
+fn table_to_decoded(
+    value: &boml::table::Table,
+) -> Result<toml_test_harness::Decoded, toml_test_harness::Error> {
+    let table: Result<_, toml_test_harness::Error> = value
+        .iter()
+        .map(|(k, v)| {
+            let k = k.to_owned();
+            let v = value_to_decoded(v)?;
+            Ok((k, v))
+        })
+        .collect();
+    Ok(toml_test_harness::Decoded::Table(table?))
+}

--- a/scripts/rust-boml/src/lib.rs
+++ b/scripts/rust-boml/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod decoder;


### PR DESCRIPTION
This is a zero-copy, decoder-only TOML library for Rust with known missing features, like full validation and datetimes